### PR TITLE
Obtain return value for Task<T>

### DIFF
--- a/InterceptionDemo/InterceptionDemo.Application/Interceptors/InternalAsyncHelper.cs
+++ b/InterceptionDemo/InterceptionDemo.Application/Interceptors/InternalAsyncHelper.cs
@@ -26,14 +26,14 @@ namespace InterceptionDemo.Interceptors
             }
         }
 
-        public static async Task<T> AwaitTaskWithPostActionAndFinallyAndGetResult<T>(Task<T> actualReturnValue, Func<Task> postAction, Action<Exception> finalAction)
+        public static async Task<T> AwaitTaskWithPostActionAndFinallyAndGetResult<T>(Task<T> actualReturnValue, Func<T, Task> postAction, Action<Exception> finalAction)
         {
             Exception exception = null;
 
             try
             {
                 var result = await actualReturnValue;
-                await postAction();
+                await postAction(result);
                 return result;
             }
             catch (Exception ex)

--- a/InterceptionDemo/InterceptionDemo.Application/Interceptors/MeasureDurationWithPostAsyncActionInterceptor.cs
+++ b/InterceptionDemo/InterceptionDemo.Application/Interceptors/MeasureDurationWithPostAsyncActionInterceptor.cs
@@ -51,7 +51,7 @@ namespace InterceptionDemo.Interceptors
                 invocation.ReturnValue = InternalAsyncHelper.CallAwaitTaskWithPostActionAndFinallyAndGetResult(
                     invocation.Method.ReturnType.GenericTypeArguments[0],
                     invocation.ReturnValue,
-                    async () => await TestActionAsync(invocation),
+                    async (object methodResult) => await TestActionAsync(invocation, methodResult),
                     ex =>
                     {
                         LogExecutionTime(invocation, stopwatch);


### PR DESCRIPTION
This proposal is for defining a post action Interceptor of an async method that obtains the TResult from the Task<TResult> return.
